### PR TITLE
ci: skip CLA checks in forks

### DIFF
--- a/.github/workflows/signature-assistant.yml
+++ b/.github/workflows/signature-assistant.yml
@@ -13,10 +13,15 @@ permissions:
 
 jobs:
   CLA-Assistant:
-    if: github.event_name == 'pull_request_target' ||
+    # Forks do not have access to the PAT used to write signatures to this repository.
+    if: |
+      github.event.repository.fork == false &&
       (
-        github.event.comment.body == 'recheck' ||
-        github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+        github.event_name == 'pull_request_target' ||
+        (
+          github.event.comment.body == 'recheck' ||
+          github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+        )
       )
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Skip the Scratch Foundation CLA job when a pull request targets a fork.

This does not disable CLA checks for contributions sent from a fork to a Scratch Foundation repository. In that case, GitHub runs the workflow from the upstream base repository, where the required organization secret is available.

## Problem

GitHub copies this workflow when a Scratch Foundation repository is forked, but repository secrets are intentionally not copied.
As a result, a pull request targeting the fork itself starts the copied CLA workflow without GHA_AGREEMENTS_PAT. The job cannot record signatures in scratchfoundation/scratch-agreements and fails even though the pull request is only part of the fork's own development.

This produces a misleading failed check for downstream projects maintaining their own changes.

  ## Behavior

  The result depends on the repository targeted by the pull request, not on where the source branch is located.

  - **A pull request targeting a personal or downstream fork**
    - The workflow runs in the fork.
    - The fork does not have the Scratch Foundation
      `GHA_AGREEMENTS_PAT` secret.
    - The CLA job is skipped.

  - **A pull request targeting a Scratch Foundation repository**
    - The workflow runs in the upstream Scratch Foundation repository.
    - The required secret is available there.
    - The CLA job runs as before.

  - **A contribution sent from a fork to Scratch Foundation**
    - For example, a pull request from `Naohiro2g/scratch-editor` to
      `scratchfoundation/scratch-editor`.
    - The base repository is `scratchfoundation/scratch-editor`.
    - The upstream workflow runs and the CLA is still checked.

  The source branch being in a fork does not disable the CLA check. The job is skipped only when the pull request targets a repository that is itself a fork.

## Non-goals

  This change does not:

  - change the CLA requirement for Scratch Foundation contributions
  - modify or invalidate existing signatures
  - change the CLA document or its version
  - copy or expose organization secrets to forks
  - provide CLA management for a downstream fork

  A fork that later submits a pull request upstream will still be checked by the upstream workflow. Existing signatures stored in scratchfoundation/scratch-agreements continue to be recognized there.

  ## Validation

  - confirmed that a pull request targeting a fork has github.event.repository.fork == true
  - confirmed that a pull request targeting a Scratch Foundation repository uses the upstream repository as github.event.repository
  - parsed the workflow as YAML
  - ran git diff --check

   ## Rollout scope

  This repository contains one copy of the CLA workflow. The same or an equivalent `signature-assistant.yml` workflow is also maintained separately in several other Scratch Foundation repositories, including:

  - `scratchfoundation/scratch-editor`
  - `scratchfoundation/scratch-blocks`
  - `scratchfoundation/scratch-www`
  - `scratchfoundation/scratch-l10n`
  - `scratchfoundation/scratch-desktop`
  - `scratchfoundation/.github`

  Additional copies currently exist in repositories such as
  `scratchfoundation/scratch-link`,
  `scratchfoundation/scratch-audio`,
  `scratchfoundation/scratch-parser`,
  `scratchfoundation/scratch-sb1-converter`,
  `scratchfoundation/scratch-webpack-configuration`,
  `scratchfoundation/scratch-renovate-config`, and
  `scratchfoundation/eslint-config-scratch`.

  Merging this PR changes only the workflow in `scratchfoundation/scratch-agreements`. It does not automatically update the copies in those other repositories.

  For example, a pull request targeting `Naohiro2g/scratch-editor` will continue to run the copied workflow from that fork until the same guard is added to `scratchfoundation/scratch-editor` and later reaches the fork through an upstream sync.

  If this behavior is accepted, the same guard should be applied to the other workflow copies through the rollout mechanism preferred by the Scratch Team. This PR intentionally does not attempt to modify multiple repositories before the behavior has been reviewed.