### PR TITLE
Fix missing negation in CLA

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -34,7 +34,7 @@ Submitting those Contributions.
 ### 3. Originality of Work
 
 You represent and warrant that each of your Contributions is entirely your original work, and that the Contribution,
-whether alone or in combination with the Project, will infringe upon or misappropriate the intellectual property or
+whether alone or in combination with the Project, will not infringe upon or misappropriate the intellectual property or
 other rights of any third party. Should you wish to Submit materials that are not your original work, you may Submit
 them separately to the Project if you (1) retain all copyright and license information that was in the materials as
 you received them, (2) in the description accompanying your Contribution, include the phrase “Contribution containing


### PR DESCRIPTION
## Summary

- add the missing `not` to the non-infringement warranty in the CLA
- correct the sentence so it no longer states that contributions will infringe third-party rights

## Context

The omitted negation was reported in #7. Since this is legal text and signatures are stored under `signatures/version1`, maintainers should confirm whether this correction remains part of version 1 or requires separate document-version handling.

## Validation

- reviewed the one-word document diff
- `git diff --check`

Fixes #7
